### PR TITLE
capture effects

### DIFF
--- a/core/src/main/scala/ToDo.scala
+++ b/core/src/main/scala/ToDo.scala
@@ -11,7 +11,7 @@ object Item {
 case class Item(
   id: Item.Id,
   content: String,
-  createdAt: Long = System.currentTimeMillis)
+  createdAt: Long)
 
 class ToDo {
   type TConfig = ToDoConfig[Task]
@@ -20,10 +20,18 @@ class ToDo {
   protected def config: ToDoK[TConfig] =
     Kleisli.ask[Task, TConfig]
 
+  protected val currentTimeMillis: ToDoK[Long] =
+    Task.delay(System.currentTimeMillis).liftKleisli
+
+  protected val randomUUID: ToDoK[UUID] =
+    Task.delay(UUID.randomUUID).liftKleisli
+
   def create(content: String): ToDoK[Item.Id] = {
      for {
       a <- config
-      i  = Item(UUID.randomUUID, content)
+      u <- randomUUID
+      t <- currentTimeMillis
+      i  = Item(u, content, t)
       b <- a.repository.create(i).liftKleisli
     } yield b
   }
@@ -34,3 +42,4 @@ class ToDo {
       b <- a.repository.list.liftKleisli
     } yield b
 }
+


### PR DESCRIPTION
`Item(UUID.randomUUID, content)` has two side-effects and no data dependency that would prevent it being relocated before the `for` comprehension in `create`, but this would cause the side-effects to happen on construction rather than on `.run`. So to avoid this kind of thing I try to be really disciplined about explicitly capturing all side-effecting operations. I would turn `currentTimeMillis` and `randomUUID` into values as below.
